### PR TITLE
修复win下盘符重复问题

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,7 +9,7 @@ import { parser } from './parse'
 
 const LOCAL_URL_REG = /^(\.|\/|\@\/)/
 
-const _projectRoot = workspace.workspaceFolders![0].uri.path
+const _projectRoot = workspace.workspaceFolders![0].uri.path.replace(/^\/([a-zA-Z])\:/, '$1:')
 const suffix = ['.ts', '.js', '.tsx', '.jsx']
 export let alias: any = null
 


### PR DESCRIPTION
win下workspace.workspaceFolders![0].uri.path获取的路径在会多一个/开头，导致后续path.resolve重复加盘符。

插件已正常。

![image](https://github.com/Simon-He95/export-what/assets/55614189/79fbd573-ea72-4d66-8373-57dd0aadf63f)